### PR TITLE
Support for syncing more than 1000 items - s3 listobjects api only li…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.idea/
 node_modules

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "s3-diff",
+  "name": "@a2d24/s3-diff",
   "version": "1.2.1",
   "description": "Get the diff between a s3-folder and a local folder",
   "main": "index.js",


### PR DESCRIPTION
The nodejs aws-sdk module's s3.listObjects function only returns up to 1000 items from the s3 bucket. If the bucket contains more than 1000 items, there is a "Truncated" flag which can be used to determine if there are more keys in the s3 bucket. The listObjects function also takes a Marker parameter which allows a user to request the next batch of keys in the bucket. Using this flag and parameter we are able to retrieve all keys from the s3 bucket, expanding the functionality you have already built.